### PR TITLE
fix: use the right returned type

### DIFF
--- a/app/db/db.py
+++ b/app/db/db.py
@@ -10,7 +10,7 @@ load_dotenv()
 db_client: AsyncIOMotorClient = None
 
 
-async def get_db() -> AsyncIOMotorClient:
+async def get_db() -> AsyncIOMotorDatabase:
     db_name = Config.app_settings.get('db_name')
     return db_client[db_name]
 


### PR DESCRIPTION
Ok I'm not so sure about this modification as I'm new to using MongoDB via Python (and I'm not a developer), but there seems to be a type error here.

I'm reinforced in this idea by the fact that the AsyncIOMotorDatabase import isn't used otherwise.